### PR TITLE
Add prependLengthPrefix

### DIFF
--- a/src/lib/predictor.ts
+++ b/src/lib/predictor.ts
@@ -75,6 +75,22 @@ class Predictor {
   }
 
   /**
+   * Skip bytes for the length prefix.
+   */
+  prependLengthPrefix (): void {
+    const length = this.size
+
+    // Skip initial byte
+    this.skip(1)
+
+    // Skip separate length field if there is one
+    if (length > 127) {
+      const lengthOfLength = Math.ceil(length.toString(2).length / 8)
+      this.skip(lengthOfLength)
+    }
+  }
+
+  /**
    * Pretend to write a series of bytes.
    *
    * @param {Buffer} Bytes to write.

--- a/src/lib/predictor.ts
+++ b/src/lib/predictor.ts
@@ -1,5 +1,6 @@
 import { isInteger } from './util'
 import BigNumber from 'bignumber.js'
+import Writer from './writer'
 
 /**
  * Writable stream which tracks the amount of data written.
@@ -14,6 +15,10 @@ class Predictor {
   constructor () {
     this.size = 0
     this.components = []
+  }
+
+  get length (): number {
+    return this.size
   }
 
   /**
@@ -63,14 +68,18 @@ class Predictor {
   /**
    * Skip bytes for a fixed-length octet string.
    */
-  writeOctetString (buffer: Buffer, length: number) {
+  writeOctetString (buffer: Buffer | Writer, length: number) {
+    if (buffer.length !== length) {
+      throw new Error('Incorrect length for octet string (actual: ' +
+        buffer.length + ', expected: ' + length + ')')
+    }
     this.skip(length)
   }
 
   /**
    * Calculate the size of a variable-length octet string.
    */
-  writeVarOctetString (buffer: Buffer) {
+  writeVarOctetString (buffer: Buffer | Writer) {
     this.skipVarOctetString(buffer.length)
   }
 
@@ -95,7 +104,7 @@ class Predictor {
    *
    * @param {Buffer} Bytes to write.
    */
-  write (bytes: Buffer) {
+  write (bytes: Buffer | Writer) {
     this.size += bytes.length
   }
 

--- a/src/lib/writer.ts
+++ b/src/lib/writer.ts
@@ -32,6 +32,14 @@ class Writer {
     this.components = []
   }
 
+  get length (): number {
+    let length = 0
+    for (let component of this.components) {
+      length += component.length
+    }
+    return length
+  }
+
   /**
    * Write a fixed-length unsigned integer to the stream.
    *
@@ -181,7 +189,7 @@ class Writer {
    * @param buffer Data to write.
    * @param length Length of data according to the format.
    */
-  writeOctetString (buffer: Buffer, length: number): void {
+  writeOctetString (buffer: Buffer | Writer, length: number): void {
     if (buffer.length !== length) {
       throw new Error('Incorrect length for octet string (actual: ' +
         buffer.length + ', expected: ' + length + ')')
@@ -228,10 +236,7 @@ class Writer {
    * Write the length prefix for the current buffer at the beginning of the buffer.
    */
   prependLengthPrefix (): void {
-    let length = 0
-    for (let buffer of this.components) {
-      length += buffer.length
-    }
+    let length = this.length
 
     const MSB = 0x80
 
@@ -251,7 +256,7 @@ class Writer {
       // Then we write the length of the buffer in that many bytes.
       lengthBuffer.writeUInt(length, lengthOfLength)
 
-      this.components.unshift(lengthBuffer.getBuffer())
+      this.components.unshift(...lengthBuffer.components)
     }
   }
 

--- a/test/predictor.spec.ts
+++ b/test/predictor.spec.ts
@@ -160,9 +160,28 @@ describe('Predictor', function () {
     it('should increment by the given length of the octet string', function () {
       const predictor = new Predictor()
 
-      predictor.writeOctetString(new Buffer(10), 5)
+      predictor.writeOctetString(Buffer.alloc(10), 10)
+
+      assert.equal(predictor.getSize(), 10)
+    })
+
+    it('should accept a Writer', function () {
+      const predictor = new Predictor()
+      const writer = new Writer()
+
+      writer.writeOctetString(Buffer.alloc(5), 5)
+      predictor.writeOctetString(writer, 5)
 
       assert.equal(predictor.getSize(), 5)
+    })
+
+    it('when writing an octet string of the wrong length, should throw', function () {
+      const predictor = new Writer()
+
+      assert.throws(
+        () => predictor.writeOctetString(new Buffer('02', 'hex'), 2),
+        'Incorrect length for octet string (actual: 1, expected: 2)'
+      )
     })
   })
 
@@ -187,6 +206,16 @@ describe('Predictor', function () {
       const predictor = new Predictor()
 
       predictor.writeVarOctetString(new Buffer(256))
+
+      assert.equal(predictor.getSize(), 259)
+    })
+
+    it('should accept a Writer', function () {
+      const predictor = new Predictor()
+      const writer = new Writer()
+
+      writer.write(Buffer.alloc(256))
+      predictor.writeVarOctetString(writer)
 
       assert.equal(predictor.getSize(), 259)
     })
@@ -227,6 +256,16 @@ describe('Predictor', function () {
       predictor.write(new Buffer(15))
 
       assert.equal(predictor.getSize(), 15)
+    })
+
+    it('should accept a Writer', function () {
+      const predictor = new Predictor()
+      const writer = new Writer()
+
+      writer.write(Buffer.alloc(256))
+      predictor.write(writer)
+
+      assert.equal(predictor.getSize(), 256)
     })
   })
 

--- a/test/predictor.spec.ts
+++ b/test/predictor.spec.ts
@@ -192,6 +192,34 @@ describe('Predictor', function () {
     })
   })
 
+  describe('prependLengthPrefix', function () {
+    it('should calculate the correct length for an empty buffer', function () {
+      const predictor = new Predictor()
+
+      predictor.prependLengthPrefix()
+
+      assert.equal(predictor.getSize(), 1)
+    })
+
+    it('should calculate the correct length for a short buffer', function () {
+      const predictor = new Predictor()
+
+      predictor.write(Buffer.alloc(10))
+      predictor.prependLengthPrefix()
+
+      assert.equal(predictor.getSize(), 11)
+    })
+
+    it('should calculate the correct length for a long buffer', function () {
+      const predictor = new Predictor()
+
+      predictor.write(Buffer.alloc(256))
+      predictor.prependLengthPrefix()
+
+      assert.equal(predictor.getSize(), 259)
+    })
+  })
+
   describe('write', function () {
     it('should add the size of the buffer to the total size', function () {
       const predictor = new Predictor()

--- a/test/writer.spec.ts
+++ b/test/writer.spec.ts
@@ -502,6 +502,25 @@ describe('Writer', function () {
       assert.equal(result.toString('hex'), '820100' + buffer.toString('hex'))
     })
 
+    it('should write another Writer', function () {
+      const a = new Writer()
+
+      const buffer = new Buffer(256)
+      buffer.fill(0xb0)
+      a.writeVarOctetString(buffer)
+
+      const b = new Writer()
+      b.writeVarOctetString(buffer)
+
+      a.write(b)
+
+      const result = a.getBuffer()
+
+      assert.equal(result.length, 259 * 2)
+      assert.equal(result.toString('hex'), '820100' + buffer.toString('hex') + '820100' + buffer.toString('hex'))
+
+    })
+
     it('when writing a non-buffer, should throw', function () {
       const writer = new Writer()
 
@@ -571,6 +590,22 @@ describe('Writer', function () {
 
       assert.equal(result.length, 256)
       assert.equal(result.toString('hex'), buffer.toString('hex'))
+    })
+
+    it('should write another writer', function () {
+      const a = new Writer()
+      const buffer = Buffer.alloc(256)
+      a.write(buffer)
+
+      const b = new Writer()
+      b.write(buffer)
+
+      a.write(b)
+
+      const result = a.getBuffer()
+
+      assert.equal(result.length, 256 * 2)
+      assert.equal(result.toString('hex'), buffer.toString('hex') + buffer.toString('hex'))
     })
   })
 

--- a/test/writer.spec.ts
+++ b/test/writer.spec.ts
@@ -512,6 +512,38 @@ describe('Writer', function () {
     })
   })
 
+  describe('prependLengthPrefix', function () {
+    it('should work for an empty buffer', function () {
+      const writer = new Writer()
+
+      writer.prependLengthPrefix()
+
+      assert.equal(writer.getBuffer().toString('hex'), '00')
+    })
+
+    it('should write a length prefix for a buffer of length 1', function () {
+      const writer = new Writer()
+
+      writer.write(new Buffer('b0', 'hex'))
+      writer.prependLengthPrefix()
+
+      assert.equal(writer.getBuffer().toString('hex'), '01b0')
+    })
+
+    it('should write a buffer of length 256', function () {
+      const writer = new Writer()
+
+      const buffer = new Buffer(256)
+      buffer.fill(0xb0)
+      writer.write(buffer)
+      writer.prependLengthPrefix()
+      const result = writer.getBuffer()
+
+      assert.equal(result.length, 259)
+      assert.equal(result.toString('hex'), '820100' + buffer.toString('hex'))
+    })
+  })
+
   describe('write', function () {
     it('should write an empty octet string', function () {
       const writer = new Writer()

--- a/test/writer.spec.ts
+++ b/test/writer.spec.ts
@@ -463,6 +463,21 @@ describe('Writer', function () {
       assert.equal(result.toString('hex'), buffer.toString('hex'))
     })
 
+    it('should accept another Writer', function () {
+      const a = new Writer()
+
+      const buffer = new Buffer(256)
+      buffer.fill(0xb0)
+
+      const b = new Writer()
+      b.writeOctetString(buffer, 256)
+      a.writeOctetString(b, 256)
+      const result = a.getBuffer()
+
+      assert.equal(result.length, 256)
+      assert.equal(result.toString('hex'), buffer.toString('hex'))
+    })
+
     it('when writing an octet string of the wrong length, should throw', function () {
       const writer = new Writer()
 


### PR DESCRIPTION
When serializing, we often call getBuffer and then writeVarOctetString for packet envelopes.
This will let us add the length prefix without re-copying the data