### PR TITLE
perf: (BREAKING) pre-allocate Writer buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import Reader from './lib/reader'
-import Writer from './lib/writer'
+import Writer, { WriterInterface } from './lib/writer'
 import Predictor from './lib/predictor'
 
-export { Reader, Writer, Predictor }
+export { Reader, Writer, WriterInterface, Predictor }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -36,3 +36,99 @@ export function bigNumberToBuffer (value: BigNumber, length?: number): Buffer {
   }
   return buffer
 }
+
+const BIG_VAR_UINT_SIZES: BigNumberSizeRange[] = [
+  { max: new BigNumber(0xff), bytes: 1 },
+  { max: new BigNumber(0xffff), bytes: 2 },
+  { max: new BigNumber(0xffffff), bytes: 3 },
+  { max: new BigNumber(0xffffffff), bytes: 4 },
+  { max: new BigNumber(0xffffffffff), bytes: 5 },
+  { max: new BigNumber(0xffffffffffff), bytes: 6 },
+  { max: new BigNumber('ffffffffffffff', 16), bytes: 7 },
+  { max: new BigNumber('ffffffffffffffff', 16), bytes: 8 }
+]
+
+const BIG_VAR_INT_SIZES: BigNumberSizeRange[] = [
+  { min: new BigNumber(-0x80), max: new BigNumber(0x7f), bytes: 1 },
+  { min: new BigNumber(-0x8000), max: new BigNumber(0x7fff), bytes: 2 },
+  { min: new BigNumber(-0x800000), max: new BigNumber(0x7fffff), bytes: 3 },
+  { min: new BigNumber(-0x80000000), max: new BigNumber(0x7fffffff), bytes: 4 },
+  { min: new BigNumber(-0x8000000000), max: new BigNumber(0x7fffffffff), bytes: 5 },
+  { min: new BigNumber(-0x800000000000), max: new BigNumber(0x7fffffffffff), bytes: 6 },
+  { min: new BigNumber('-80000000000000', 16), max: new BigNumber('7fffffffffffff', 16), bytes: 7 },
+  { min: new BigNumber('-8000000000000000', 16), max: new BigNumber('7fffffffffffffff', 16), bytes: 8 }
+]
+
+const VAR_UINT_SIZES: NumberSizeRange[] = makeNumberRanges(BIG_VAR_UINT_SIZES)
+const VAR_INT_SIZES: NumberSizeRange[] = makeNumberRanges(BIG_VAR_INT_SIZES)
+
+// Returns the minimum number of bytes required to encode the value.
+export function getBigUIntBufferSize (value: BigNumber): number {
+  for (let i = 0; i < BIG_VAR_UINT_SIZES.length; i++) {
+    const item = BIG_VAR_UINT_SIZES[i]
+    if (value.isLessThanOrEqualTo(item.max)) {
+      // Fast path: no extra work converting a BigNumber to a String.
+      return item.bytes
+    }
+  }
+  return computeBigNumberBufferSize(value)
+}
+
+export function getUIntBufferSize (value: number): number {
+  for (let i = 0; i < VAR_UINT_SIZES.length; i++) {
+    const item = VAR_UINT_SIZES[i]
+    if (value <= item.max) return item.bytes
+  }
+  return computeBigNumberBufferSize(new BigNumber(value))
+}
+
+// Returns the minimum number of bytes required to encode the value.
+export function getBigIntBufferSize (value: BigNumber): number {
+  for (let i = 0; i < VAR_INT_SIZES.length; i++) {
+    const item = VAR_INT_SIZES[i]
+    if (
+      value.isGreaterThanOrEqualTo(item.min!) &&
+      value.isLessThanOrEqualTo(item.max)
+    ) {
+      // Fast path: no extra work converting a BigNumber to a String.
+      return item.bytes
+    }
+  }
+  return computeBigNumberBufferSize(value)
+}
+
+export function getIntBufferSize (value: number): number {
+  for (let i = 0; i < VAR_INT_SIZES.length; i++) {
+    const item = VAR_INT_SIZES[i]
+    if (value >= item.min! && value <= item.max) return item.bytes
+  }
+  return computeBigNumberBufferSize(new BigNumber(value))
+}
+
+function computeBigNumberBufferSize (value: BigNumber): number {
+  return Math.ceil(value.toString(16).length / 2)
+}
+
+interface BigNumberSizeRange {
+  // UInt ranges don't use min.
+  min?: BigNumber,
+  max: BigNumber,
+  bytes: number
+}
+
+interface NumberSizeRange {
+  // UInt ranges don't use min.
+  min?: number,
+  max: number,
+  bytes: number
+}
+
+function makeNumberRanges (ranges: BigNumberSizeRange[]): NumberSizeRange[] {
+  return ranges
+    .filter((range) => range.bytes <= MAX_SAFE_BYTES)
+    .map((range) => ({
+      min: range.min && range.min.toNumber(),
+      max: range.max.toNumber(),
+      bytes: range.bytes
+    }))
+}

--- a/test/reader.spec.ts
+++ b/test/reader.spec.ts
@@ -119,6 +119,24 @@ describe('Reader', function () {
       assert.isNumber(v)
       assert.equal(v, 16909060)
     })
+
+    it('should throw if asked to read a zero-length number', function () {
+      const reader = Reader.from(Buffer.from('01', 'hex'))
+
+      assert.throw(
+        () => reader.readUIntNumber(0),
+        'UInt length must be greater than zero'
+      )
+    })
+
+    it('should throw if asked to read a too-long number', function () {
+      const reader = Reader.from(Buffer.from('01020304050607', 'hex'))
+
+      assert.throw(
+        () => reader.readUIntNumber(7),
+        'Value does not fit a JS number without sacrificing precision'
+      )
+    })
   })
 
   describe('readUIntBigNum', function () {
@@ -376,6 +394,24 @@ describe('Reader', function () {
       assert.isNumber(v2)
       assert.equal(v1, -1)
       assert.equal(v2, 2)
+    })
+
+    it('should throw if asked to read a zero-length number', function () {
+      const reader = Reader.from(Buffer.from('01', 'hex'))
+
+      assert.throw(
+        () => reader.readIntNumber(0),
+        'Int length must be greater than zero'
+      )
+    })
+
+    it('should throw if asked to read a too-long number', function () {
+      const reader = Reader.from(Buffer.from('01020304050607', 'hex'))
+
+      assert.throw(
+        () => reader.readIntNumber(7),
+        'Value does not fit a JS number without sacrificing precision'
+      )
     })
   })
 

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -1,0 +1,33 @@
+import * as util from '../src/lib/util'
+import BigNumber from 'bignumber.js'
+
+import chai = require('chai')
+const assert = chai.assert
+
+describe('util', function () {
+  describe('getUIntBufferSize', function () {
+    it('returns the same values as getBigUIntBufferSize', function () {
+      const max = 0x7fffffffffff
+      for (let i = 0; i < 1000; i++) {
+        const value = Math.floor(max * Math.random())
+        const numBuf = util.getUIntBufferSize(value)
+        const bigBuf = util.getBigUIntBufferSize(new BigNumber(value))
+        assert.equal(numBuf, bigBuf, 'mismatch for value=' + value)
+      }
+    })
+  })
+
+  describe('getIntBufferSize', function () {
+    it('returns the same values as getBigIntBufferSize', function () {
+      const max = 0x7fffffffffff
+      for (let i = 0; i < 1000; i++) {
+        let value = Math.floor(max * Math.random())
+        if (Math.random() < 0.5) value = -value
+
+        const numBuf = util.getIntBufferSize(value)
+        const bigBuf = util.getBigIntBufferSize(new BigNumber(value))
+        assert.equal(numBuf, bigBuf, 'mismatch for value=' + value)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Optimize packet serialization/deserialization by reducing the number of `Buffer` allocations and avoiding bignum operations when numbers will suffice.

See also:
- https://github.com/interledgerjs/ilp-packet/pull/53
- https://github.com/interledgerjs/btp-packet/pull/34
- https://github.com/interledgerjs/ilp-protocol-stream/pull/97

## Breaking changes:

  - `Predictor` can no longer be used directly as a `Writer`. Instead, both `Predictor` and `Writer` implement `WriterInterface`.
  - `write`/`writeOctetString`/`writeVarOctetString` can no longer receive a `Writer`. Because the `Writer` doesn't keep a list of component buffers, there's no efficiency gain to this. `createVarOctetString` is faster, anyway.

## Features:

  - Add `Predictor.measureVarOctetString`, which is useful when calculating a `Writer`'s buffer size in advance.
  - Add `{Predictor,Writer}.createVarOctetString` (see below).

## Bug fixes:

  - `writeUInt`/`writeInt`: Fix length check for large bignums (>6 bytes).

## Optimizations:

### `Writer` / `Predictor`:

  - `writeVarUInt`/`writeVarInt`: avoid creating `BigNumber`s when possible (in both `Writer` and `Predictor`). Use `writeUInt`/`writeInt` to write numbers without allocating buffers or bignums.
  - Calculating the buffer size of numbers/bignums is much faster, and can usually avoid stringifying the number/bignumber (which is slow).
  - `createVarOctetString` is used to construct a pre-allocated OER-encoded VarOctetString (replacing `writeVarOctetString(otherWriter)`).
  - A `Writer` constructor can be passed an exact capacity, which will allow it to only allocate a buffer once. If no capacity is provided, it will allocate a small initial buffer, then resize when it is filled. The former method is fastest by far, but the latter is still faster than the old strategy of constructing a list of buffers and concatenating them at the end.

### `Reader`:

  - `readLengthPrefix`: `use `readUInt8Number()` instead of `readUInt8BigNum().toNumber()` to get the length.

## Benchmarks
(v0: before; v1: after):

### ilp-packet

```
serializeIlpPrepare      v0 x 224,294 ops/sec ±0.84% (91 runs sampled)
serializeIlpPrepare      v1 x 418,535 ops/sec ±0.88% (91 runs sampled)
deserializeIlpPrepare    v0 x 236,698 ops/sec ±1.28% (91 runs sampled)
deserializeIlpPrepare    v1 x 322,443 ops/sec ±0.45% (91 runs sampled)
serializeIlpFulfill      v0 x 537,387 ops/sec ±0.86% (90 runs sampled)
serializeIlpFulfill      v1 x 1,054,131 ops/sec ±1.20% (88 runs sampled)
deserializeIlpFulfill    v0 x 1,079,358 ops/sec ±0.68% (94 runs sampled)
deserializeIlpFulfill    v1 x 4,630,731 ops/sec ±1.60% (89 runs sampled)
serializeIlpReject       v0 x 260,279 ops/sec ±0.82% (88 runs sampled)
serializeIlpReject       v1 x 457,782 ops/sec ±0.98% (91 runs sampled)
deserializeIlpReject     v0 x 478,236 ops/sec ±0.69% (97 runs sampled)
deserializeIlpReject     v1 x 1,333,481 ops/sec ±1.00% (89 runs sampled)
```

### btp-packet:
(benchmarks a `Message` packet with a single `ilp` subprotocol)

```
serialize:   Message     v0 x 250,978 ops/sec ±0.85% (91 runs sampled)
serialize:   Message     v1 x 862,162 ops/sec ±1.08% (94 runs sampled)
deserialize: Message     v0 x 735,601 ops/sec ±1.88% (94 runs sampled)
deserialize: Message     v1 x 2,605,169 ops/sec ±0.60% (92 runs sampled)
```

### ilp-protocol-stream:
(note that these benchmarks don't include encryption/decryption)

```
serialize:   MoneyFrame          v0 x 25,560 ops/sec ±0.84% (93 runs sampled)
serialize:   MoneyFrame          v1 x 116,407 ops/sec ±1.60% (95 runs sampled)
deserialize: MoneyFrame          v0 x 114,379 ops/sec ±2.44% (89 runs sampled)
deserialize: MoneyFrame          v1 x 206,280 ops/sec ±0.55% (90 runs sampled)
```